### PR TITLE
ci: update documentation workflow triggers

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,9 +1,10 @@
 name: Documentation
 
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 
 permissions:
   pages: write


### PR DESCRIPTION
This way it should run whenever we deploy a new version but also if we need to manually run/re-run.