### PR TITLE
fix: use correct callbacks for safari extension notifications

### DIFF
--- a/src/models/aspera-desktop.model.ts
+++ b/src/models/aspera-desktop.model.ts
@@ -146,7 +146,7 @@ export class ActivityTracking {
       return;
     }
 
-    this.event_callbacks.forEach(callback => {
+    this.safari_extension_callbacks.forEach(callback => {
       if (typeof callback === 'function') {
         callback(safariExtensionEvent);
       }


### PR DESCRIPTION
Fix to use correct callbacks for Safari extension status notifications